### PR TITLE
Enhanced feed attributes and multi-lang support

### DIFF
--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -121,8 +121,10 @@
         {{ printf `<summary type="html"><![CDATA[%s]]></summary>` .Summary | safeHTML }}
       {{- end }}
       {{- $description1 := .Description | default "" }}
-      {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify))) }}
-      {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+      {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify | chomp ))) }}
+      {{- if and (ne .Content "") (ne $description "") }}
+        {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+      {{- end }}
       {{- with site.Taxonomies }}
         {{- range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
           {{- with $page.Param $taxo }}

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -1,143 +1,143 @@
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <feed xmlns="http://www.w3.org/2005/Atom"{{ with site.LanguageCode }} xml:lang="{{.}}"{{- end -}}>
-  {{- $uuid := sha1 $.Site.BaseURL }}
-  <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
-  <title type="html">
-    {{- if ne .Title site.Title }}
-      {{- with .Title }}{{. | html }} | {{- end -}}
-    {{- end -}}
-    {{- site.Title | html }}
-    {{- if .IsTranslated }} ({{- index site.Data.i18n.languages .Lang }}){{- end -}}
-  </title>
-  {{- if (.Params.Subtitle) and (ne .Params.Subtitle "") }}
-    <subtitle type="html">
-      {{- .Params.Subtitle | html -}}
-    </subtitle>
-  {{- else if ($.Site.Params.Subtitle) and (ne $.Site.Params.Subtitle "") }}
-    <subtitle type="html">
-      {{- $.Site.Params.Subtitle | html -}}
-    </subtitle>
-  {{- end }}
-  {{ with .OutputFormats.Get "HTML" }}
-    {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"Website\" />" .Permalink .MediaType | safeHTML }}
-  {{- end }}
-  {{ with .OutputFormats.Get "ATOM" }}
-    {{- printf "<link href=%q rel=\"self\" type=%q title=\"Atom/Modern feed format\" />" .Permalink .MediaType | safeHTML }}
-  {{- end }}
-  {{ with .OutputFormats.Get "RSS" }}
-    {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"RSS/Legacy feed format\" />" .Permalink .MediaType | safeHTML }}
-  {{- end }}
-  {{- range .Translations }}
-    {{- $lang := .Lang }}
-    {{- $langstr := index site.Data.i18n.languages .Lang }}
+    {{- $uuid := sha1 $.Site.BaseURL }}
+    <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
+    <title type="html">
+        {{- if ne .Title site.Title }}
+            {{- with .Title }}{{. | html }} | {{- end -}}
+        {{- end -}}
+        {{- site.Title | html }}
+        {{- if .IsTranslated }} ({{- index site.Data.i18n.languages .Lang }}){{- end -}}
+    </title>
+    {{- if (.Params.Subtitle) and (ne .Params.Subtitle "") }}
+        <subtitle type="html">
+            {{- .Params.Subtitle | html -}}
+        </subtitle>
+    {{- else if ($.Site.Params.Subtitle) and (ne $.Site.Params.Subtitle "") }}
+        <subtitle type="html">
+            {{- $.Site.Params.Subtitle | html -}}
+        </subtitle>
+    {{- end }}
     {{ with .OutputFormats.Get "HTML" }}
-      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Website\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"Website\" />" .Permalink .MediaType | safeHTML }}
     {{- end }}
     {{ with .OutputFormats.Get "ATOM" }}
-      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Atom/Modern feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- printf "<link href=%q rel=\"self\" type=%q title=\"Atom/Modern feed format\" />" .Permalink .MediaType | safeHTML }}
     {{- end }}
     {{ with .OutputFormats.Get "RSS" }}
-      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] RSS/Legacy feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"RSS/Legacy feed format\" />" .Permalink .MediaType | safeHTML }}
     {{- end }}
-  {{- end }}
-  {{- if and (eq site.Params.comments.engine 1) (site.Params.comments.disqus.shortname) }}
-    <link href="https://{{- site.Params.comments.disqus.shortname }}.disqus.com/comments.rss" rel="comments" type="application/rss+xml" />
-  {{- end }}
-  <generator uri="https://gohugo.io/" version="{{hugo.Version}}">Hugo</generator>
-  {{- $author := site.GetPage (printf "/%s/%s" "authors" (.Scratch.Get "superuser_username")) }}
-  {{ with site.Author.name }}
-    <author>
-      <name>{{ . | plainify }}</name>
-      {{- with site.Author.email }}
-        <email>{{ . | plainify }}</email>
-      {{- end }}
-    </author>
-  {{- else }}
-    {{- with $author }}
-      <author>
-        <name>{{ .Params.name }}</name>
-        <uri>{{ .Permalink }}</uri>
-        {{- /* with .Params.email }}
-          <email>{{ . | plainify }}</email>
-        {{ end */ -}}
-      </author>
-    {{- end -}}
-  {{- end -}}
-  {{ with site.Copyright }}
-    <rights>
-      {{- replace (replace . "{year}" now.Year) "&copy;" "©" | plainify -}}
-    </rights>
-  {{- end }}
-  <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-  <icon>
-    {{- site.BaseURL }}img/icon-32.png{{- "" -}}
-  </icon>
-  <logo>
-    {{- site.BaseURL }}img/icon-512.png{{- "" -}}
-  </logo>
-
-  {{- $limit := (cond (le site.Config.Services.RSS.Limit 0) 65536 site.Config.Services.RSS.Limit) }}
-  {{- $feed_sections := $.Site.Params.feedSections | default site.Params.mainSections }}
-  {{ range first $limit (where (where .Pages "Type" "in" $feed_sections) ".Params.DisableFeed" "!=" true ) }}
-    {{ $page := . }}
-    <entry>
-      {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
-      {{- $uuid := sha1 .RelPermalink }}
-      <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
-      {{- with .Params.authors -}}
-        {{- range . -}} <!-- Assuming the author front-matter to be a list -->
-          {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
-          {{- if $author.Params.name }}
-            {{- with $author }}
-              <author>
+    {{- range .Translations }}
+        {{- $lang := .Lang }}
+        {{- $langstr := index site.Data.i18n.languages .Lang }}
+        {{ with .OutputFormats.Get "HTML" }}
+            {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Website\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- end }}
+        {{ with .OutputFormats.Get "ATOM" }}
+            {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Atom/Modern feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- end }}
+        {{ with .OutputFormats.Get "RSS" }}
+            {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] RSS/Legacy feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+        {{- end }}
+    {{- end }}
+    {{- if and (eq site.Params.comments.engine 1) (site.Params.comments.disqus.shortname) }}
+        <link href="https://{{- site.Params.comments.disqus.shortname }}.disqus.com/comments.rss" rel="comments" type="application/rss+xml" />
+    {{- end }}
+    <generator uri="https://gohugo.io/" version="{{hugo.Version}}">Hugo</generator>
+    {{- $author := site.GetPage (printf "/%s/%s" "authors" (.Scratch.Get "superuser_username")) }}
+    {{ with site.Author.name }}
+        <author>
+            <name>{{ . | plainify }}</name>
+            {{- with site.Author.email }}
+                <email>{{ . | plainify }}</email>
+            {{- end }}
+        </author>
+    {{- else }}
+        {{- with $author }}
+            <author>
                 <name>{{ .Params.name }}</name>
                 <uri>{{ .Permalink }}</uri>
                 {{- /* with .Params.email }}
-                  <email>{{ . | plainify }}</email>
+                    <email>{{ . | plainify }}</email>
                 {{ end */ -}}
-              </author>
-            {{- end -}}
-          {{- else }}
-            <author>
-              <name>{{ . }}</name>
             </author>
-          {{- end -}}
         {{- end -}}
-      {{- end }}
-      <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
-      <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-      <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
-      {{- range .Translations }}
-        {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
-        {{- printf "<link href=%q rel=\"alternate\" type=\"text/html\" hreflang=%q />" $link .Lang | safeHTML }}
-      {{- end }}
-      {{- if site.Params.comments.engine | and (index site.Params.comments.commentable .Type) | and (ne .Params.commentable false) | or .Params.commentable }}
-        <link href="{{ .Permalink }}?utm_source=atom_feed#comments" rel="service.post" type="text/html" />
-      {{- end }}
-      {{- range first 5 (site.RegularPages.Related .) }}
-        <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
-      {{- end }}
-      {{- if ne .Summary "" }}
-        {{ printf `<summary type="html"><![CDATA[%s]]></summary>` .Summary | safeHTML }}
-      {{- end }}
-      {{- $description1 := .Description | default "" }}
-      {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify | chomp ))) }}
-      {{- if or (ne .Content "") (ne $description "") }}
-        {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
-      {{- end }}
-      {{- with site.Taxonomies }}
-        {{- range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
-          {{- with $page.Param $taxo }}
-            {{- $taxo_list := . }} <!-- $taxo_list will be the tags/categories list -->
-            {{- with site.GetPage (printf "/%s" $taxo) }}
-              {{- $taxonomy_page := . }}
-              {{- range $taxo_list }} <!-- Below, assuming pretty URLs -->
-                <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
-              {{- end }}
+    {{- end -}}
+    {{ with site.Copyright }}
+        <rights>
+            {{- replace (replace . "{year}" now.Year) "&copy;" "©" | plainify -}}
+        </rights>
+    {{- end }}
+    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+    <icon>
+        {{- site.BaseURL }}img/icon-32.png{{- "" -}}
+    </icon>
+    <logo>
+        {{- site.BaseURL }}img/icon-512.png{{- "" -}}
+    </logo>
+
+    {{- $limit := (cond (le site.Config.Services.RSS.Limit 0) 65536 site.Config.Services.RSS.Limit) }}
+    {{- $feed_sections := $.Site.Params.feedSections | default site.Params.mainSections }}
+    {{ range first $limit (where (where .Pages "Type" "in" $feed_sections) ".Params.DisableFeed" "!=" true ) }}
+        {{ $page := . }}
+        <entry>
+            {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
+            {{- $uuid := sha1 .RelPermalink }}
+            <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
+            {{- with .Params.authors -}}
+                {{- range . -}} <!-- Assuming the author front-matter to be a list -->
+                    {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
+                    {{- if $author.Params.name }}
+                        {{- with $author }}
+                            <author>
+                                <name>{{ .Params.name }}</name>
+                                <uri>{{ .Permalink }}</uri>
+                                {{- /* with .Params.email }}
+                                    <email>{{ . | plainify }}</email>
+                                {{ end */ -}}
+                            </author>
+                        {{- end -}}
+                    {{- else }}
+                        <author>
+                            <name>{{ . }}</name>
+                        </author>
+                    {{- end -}}
+                {{- end -}}
             {{- end }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-    </entry>
-  {{ end }}
+            <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
+            <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+            <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
+            {{- range .Translations }}
+                {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
+                {{- printf "<link href=%q rel=\"alternate\" type=\"text/html\" hreflang=%q />" $link .Lang | safeHTML }}
+            {{- end }}
+            {{- if site.Params.comments.engine | and (index site.Params.comments.commentable .Type) | and (ne .Params.commentable false) | or .Params.commentable }}
+                <link href="{{ .Permalink }}?utm_source=atom_feed#comments" rel="service.post" type="text/html" />
+            {{- end }}
+            {{- range first 5 (site.RegularPages.Related .) }}
+                <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
+            {{- end }}
+            {{- if ne .Summary "" }}
+                {{ printf `<summary type="html"><![CDATA[%s]]></summary>` .Summary | safeHTML }}
+            {{- end }}
+            {{- $description1 := .Description | default "" }}
+            {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify | chomp ))) }}
+            {{- if or (ne .Content "") (ne $description "") }}
+                {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+            {{- end }}
+            {{- with site.Taxonomies }}
+                {{- range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
+                    {{- with $page.Param $taxo }}
+                        {{- $taxo_list := . }} <!-- $taxo_list will be the tags/categories list -->
+                        {{- with site.GetPage (printf "/%s" $taxo) }}
+                            {{- $taxonomy_page := . }}
+                            {{- range $taxo_list }} <!-- Below, assuming pretty URLs -->
+                                <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
+                            {{- end }}
+                        {{- end }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+        </entry>
+    {{ end }}
 </feed>

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -122,7 +122,7 @@
       {{- end }}
       {{- $description1 := .Description | default "" }}
       {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify | chomp ))) }}
-      {{- if and (ne .Content "") (ne $description "") }}
+      {{- if or (ne .Content "") (ne $description "") }}
         {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
       {{- end }}
       {{- with site.Taxonomies }}

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -1,22 +1,23 @@
-{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
-<feed xmlns="http://www.w3.org/2005/Atom"{{ with site.LanguageCode }} xml:lang="{{.}}"{{- end -}}>
-    {{- $uuid := sha1 $.Site.BaseURL }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
+<feed xmlns="http://www.w3.org/2005/Atom"{{ with site.LanguageCode }} xml:lang="{{.}}"{{ end }}>
+    <generator uri="https://gohugo.io/" version="{{ hugo.Version }}">Hugo</generator>
+    {{ $uuid := sha1 $.Site.BaseURL -}}
     <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
-    <title type="html">
+    {{ printf `<title type="html"><![CDATA[` | safeHTML }}
         {{- if ne .Title site.Title }}
-            {{- with .Title }}{{. | html }} | {{- end -}}
+            {{- with .Title }}{{. | safeHTML }} | {{ end -}}
         {{- end -}}
-        {{- site.Title | html }}
-        {{- if .IsTranslated }} ({{- index site.Data.i18n.languages .Lang }}){{- end -}}
-    </title>
-    {{- if (.Params.Subtitle) and (ne .Params.Subtitle "") }}
-        <subtitle type="html">
-            {{- .Params.Subtitle | html -}}
-        </subtitle>
-    {{- else if ($.Site.Params.Subtitle) and (ne $.Site.Params.Subtitle "") }}
-        <subtitle type="html">
-            {{- $.Site.Params.Subtitle | html -}}
-        </subtitle>
+        {{- site.Title | safeHTML }}
+        {{- if .IsTranslated }} ({{- index site.Data.i18n.languages .Lang }}){{ end -}}
+    {{ printf `]]></title>` | safeHTML }}
+    {{- if (.Params.subtitle) and (ne .Params.subtitle "") }}
+        {{ printf `<subtitle type="html"><![CDATA[` | safeHTML }}
+            {{- .Params.subtitle | safeHTML -}}
+        {{ printf `]]></subtitle>` | safeHTML }}
+    {{- else if ($.Site.Params.subtitle) and (ne $.Site.Params.subtitle "") }}
+        {{ printf `<subtitle type="html"><![CDATA[` | safeHTML }}
+            {{- $.Site.Params.subtitle | safeHTML -}}
+        {{ printf `]]></subtitle>` | safeHTML }}
     {{- end }}
     {{ with .OutputFormats.Get "HTML" }}
         {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"Website\" />" .Permalink .MediaType | safeHTML }}
@@ -43,42 +44,234 @@
     {{- if and (eq site.Params.comments.engine 1) (site.Params.comments.disqus.shortname) }}
         <link href="https://{{- site.Params.comments.disqus.shortname }}.disqus.com/comments.rss" rel="comments" type="application/rss+xml" />
     {{- end }}
-    <generator uri="https://gohugo.io/" version="{{hugo.Version}}">Hugo</generator>
-    {{- $author := site.GetPage (printf "/%s/%s" "authors" (.Scratch.Get "superuser_username")) }}
-    {{ with site.Author.name }}
-        <author>
-            <name>{{ . | plainify }}</name>
-            {{- with site.Author.email }}
-                <email>{{ . | plainify }}</email>
-            {{- end }}
-        </author>
-    {{- else }}
-        {{- with $author }}
+    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+
+    {{ $authors := "" }}
+    {{ if isset site "Author" }}
+        {{ $authors = site.Author }}
+    {{ else if isset site "Authors" }}
+        {{ $authors = site.Authors }}
+    {{ else if isset site "author" }}
+        {{ $authors = site.author }}
+    {{ else if isset site "authors" }}
+        {{ $authors = site.authors }}
+    {{ else if isset site.Params "Author" }}
+        {{ $authors = site.Params.Author }}
+    {{ else if isset site.Params "Authors" }}
+        {{ $authors = site.Params.Authors }}
+    {{ else if isset site.Params "author" }}
+        {{ $authors = site.Params.author }}
+    {{ else if isset site.Params "authors" }}
+        {{ $authors = site.Params.authors }}
+    {{ end }}
+    {{ if and $authors (reflect.IsSlice $authors) }} <!-- if authors are defined as slice -->
+        {{ range $authors }}
+            {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
             <author>
-                <name>{{ .Params.name }}</name>
-                <uri>{{ .Permalink }}</uri>
-                {{- /* with .Params.email }}
-                    <email>{{ . | plainify }}</email>
-                {{ end */ -}}
+                {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                    <name>{{ $author.Params.name | plainify }}</name>
+                {{- else -}}
+                    <name>{{ . | plainify }}</name>
+                {{- end -}}
+                {{- if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                    <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                {{- else if $author }} <!-- link to profile page -->
+                    <uri>{{ $author.Permalink }}</uri>
+                {{- end -}}
+                {{- if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                    <email>{{ $author.Params.email | safeHTML }}</email>
+                {{- end -}}
             </author>
+        {{ end }}
+    {{ else if and $authors (reflect.IsMap $authors) }} <!-- if authors are defined as map -->
+        {{ if isset $authors "name" }} <!-- this is a single author map -->
+            {{ with $authors }}
+                {{- $author := site.GetPage (printf "/%s/%s" "authors" .name) }}
+                <author>
+                    {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                        <name>{{ $author.Params.name | plainify }}</name>
+                    {{- else -}}
+                        <name>{{ .name | plainify }}</name>
+                    {{- end -}}
+                    {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                        <uri>{{ .uri | safeHTML }}</uri>
+                    {{- else if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                        <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                    {{- else if $author }} <!-- link to profile page -->
+                        <uri>{{ $author.Permalink }}</uri>
+                    {{- end -}}
+                    {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                        <email>{{ .email | plainify }}</email>
+                    {{- else if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                        <email>{{ $author.Params.email | safeHTML }}</email>
+                    {{- end -}}
+                </author>
+            {{ end }}
+        {{ else }} <!-- this is a multi author map -->
+            {{ range $elem_index, $elem_val := $authors }}
+                {{- $name := $elem_index }}
+                {{ if isset . "name" }}
+                    {{- $name = .name }}
+                {{ end }}
+                {{- $author := site.GetPage (printf "/%s/%s" "authors" $name) }}
+                <author>
+                    {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                        <name>{{ $author.Params.name | plainify }}</name>
+                    {{- else -}}
+                        <name>{{ $name | plainify }}</name>
+                    {{- end -}}
+                    {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                        <uri>{{ .uri | safeHTML }}</uri>
+                    {{- else if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                        <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                    {{- else if $author }} <!-- link to profile page -->
+                        <uri>{{ $author.Permalink }}</uri>
+                    {{- end -}}
+                    {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                        <email>{{ .email | plainify }}</email>
+                    {{- else if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                        <email>{{ $author.Params.email | safeHTML }}</email>
+                    {{- end -}}
+                </author>
+            {{ end }}
+        {{ end }}
+    {{ else if $authors }} <!-- simple author name -->
+        <author><name>{{ $authors | plainify }}</name></author>
+    {{- else }}
+        {{- $author := site.GetPage (printf "/%s/%s" "authors" (.Scratch.Get "superuser_username")) }}
+        {{- if $author.Params.name }} <!-- fallback: a profile page for a superuser was found -->
+            {{ with $author }}
+                <author>
+                    <name>{{ .Params.name | plainify }}</name>
+                    {{ with site.Author.uri }} <!-- author uri may be overwritten for site level -->
+                        <uri>{{ . | safeHTML }}</uri>
+                    {{ else -}}
+                        <uri>{{ .Permalink }}</uri>
+                    {{ end -}}
+                    {{ with site.Author.email }} <!-- author email may be overwritten for site level -->
+                        <email>{{ . | plainify }}</email>
+                    {{ else -}}
+                        {{- with .Params.email }} <!-- default: author email from profile page disabled for privacy reasons -->
+                            <email>{{ . | plainify }}</email>
+                        {{ end -}}
+                    {{ end -}}
+                </author>
+            {{- end -}}
         {{- end -}}
     {{- end -}}
+
+    {{ $contributors := "" }}
+    {{ if isset site "Contributor" }}
+        {{ $contributors = site.Contributor }}
+    {{ else if isset site "Contributors" }}
+        {{ $contributors = site.Contributors }}
+    {{ else if isset site "contributor" }}
+        {{ $contributors = site.contributor }}
+    {{ else if isset site "contributors" }}
+        {{ $contributors = site.contributors }}
+    {{ else if isset site.Params "Contributor" }}
+        {{ $contributors = site.Params.Contributor }}
+    {{ else if isset site.Params "Contributors" }}
+        {{ $contributors = site.Params.Contributors }}
+    {{ else if isset site.Params "contributor" }}
+        {{ $contributors = site.Params.contributor }}
+    {{ else if isset site.Params "contributors" }}
+        {{ $contributors = site.Params.contributors }}
+    {{ end }}
+    {{ if and $contributors (reflect.IsSlice $contributors) }} <!-- if contributors are defined as slice -->
+        {{ range $contributors }}
+            {{- $contributor := site.GetPage (printf "/%s/%s" "authors" .) }}
+            <contributor>
+                {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                    <name>{{ $contributor.Params.name | plainify }}</name>
+                {{- else -}}
+                    <name>{{ . | plainify }}</name>
+                {{- end -}}
+                {{- if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                    <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                {{- else if $contributor }} <!-- link to profile page -->
+                    <uri>{{ $contributor.Permalink }}</uri>
+                {{- end -}}
+                {{- if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                    <email>{{ $contributor.Params.email | safeHTML }}</email>
+                {{- end -}}
+            </contributor>
+        {{ end }}
+    {{ else if and $contributors (reflect.IsMap $contributors) }} <!-- if contributors are defined as map -->
+        {{ if isset $contributors "name" }} <!-- this is a single contributor map -->
+            {{ with $contributors }}
+                {{- $contributor := site.GetPage (printf "/%s/%s" "authors" .name) }}
+                <contributor>
+                    {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                        <name>{{ $contributor.Params.name | plainify }}</name>
+                    {{- else -}}
+                        <name>{{ .name | plainify }}</name>
+                    {{- end -}}
+                    {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                        <uri>{{ .uri | safeHTML }}</uri>
+                    {{- else if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                        <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                    {{- else if $contributor }} <!-- link to profile page -->
+                        <uri>{{ $contributor.Permalink }}</uri>
+                    {{- end -}}
+                    {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                        <email>{{ .email | plainify }}</email>
+                    {{- else if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                        <email>{{ $contributor.Params.email | safeHTML }}</email>
+                    {{- end -}}
+                </contributor>
+            {{ end }}
+        {{ else }} <!-- this is a multi contributor map -->
+            {{ range $elem_index, $elem_val := $contributors }}
+                {{- $name := $elem_index }}
+                {{ if isset . "name" }}
+                    {{- $name = .name }}
+                {{ end }}
+                {{- $contributor := site.GetPage (printf "/%s/%s" "authors" $name) }}
+                <contributor>
+                    {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                        <name>{{ $contributor.Params.name | plainify }}</name>
+                    {{- else -}}
+                        <name>{{ $name | plainify }}</name>
+                    {{- end -}}
+                    {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                        <uri>{{ .uri | safeHTML }}</uri>
+                    {{- else if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                        <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                    {{- else if $contributor }} <!-- link to profile page -->
+                        <uri>{{ $contributor.Permalink }}</uri>
+                    {{- end -}}
+                    {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                        <email>{{ .email | plainify }}</email>
+                    {{- else if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                        <email>{{ $contributor.Params.email | safeHTML }}</email>
+                    {{- end -}}
+                </contributor>
+            {{ end }}
+        {{ end }}
+    {{ else if $contributors }} <!-- simple contributor name -->
+        <contributor><name>{{ $contributors | plainify }}</name></contributor>
+    {{ end }}
     {{ with site.Copyright }}
         <rights>
             {{- replace (replace . "{year}" now.Year) "&copy;" "©" | plainify -}}
         </rights>
     {{- end }}
-    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-    <icon>
-        {{- site.BaseURL }}img/icon-32.png{{- "" -}}
-    </icon>
-    <logo>
-        {{- site.BaseURL }}img/icon-512.png{{- "" -}}
-    </logo>
-
+    {{- $icon := site.Params.feedicon | default "icon-32.png" -}}
+    {{- $iconpaths := printf "static/img/%s" $icon -}}
+    {{- $iconpath := printf "img/%s" $icon -}}
+    {{- if (fileExists $iconpaths) }}
+        <icon>{{ $iconpath | absURL }}</icon>
+    {{- end }}
+    {{- $logo := site.Params.feedlogo | default "logo.svg" -}}
+    {{- $logopaths := printf "static/img/%s" $logo -}}
+    {{- $logopath := printf "img/%s" $logo -}}
+    {{- if (fileExists $logopaths) }}
+        <logo>{{ $logopath | absURL }}</logo>
+    {{- end }}
     {{- $limit := (cond (le site.Config.Services.RSS.Limit 0) 65536 site.Config.Services.RSS.Limit) }}
     {{- $feed_sections := $.Site.Params.feedSections | default site.Params.mainSections }}
-    {{ range first $limit (where (where .Pages "Type" "in" $feed_sections) ".Params.DisableFeed" "!=" true ) }}
+    {{ range first $limit (where (where .Pages "Type" "in" $feed_sections) ".Params.disablefeed" "!=" true ) }}
         {{ $page := . }}
         <entry>
             {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
@@ -95,26 +288,169 @@
             {{- end }}
             {{- $uuid := sha1 .RelPermalink }}
             <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
-            {{- with .Params.authors -}}
-                {{- range . -}} <!-- Assuming the authors front-matter to be a list -->
+
+            {{ $authors := "" }}
+            {{ if isset .Params "author" }}
+                {{ $authors = .Params.author }}
+            {{ else if isset .Params "authors" }}
+                {{ $authors = .Params.authors }}
+            {{ end }}
+            {{ if and $authors (reflect.IsSlice $authors) }} <!-- if authors are defined as slice -->
+                {{ range $authors }}
                     {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
-                    {{- if $author.Params.name }}
-                        {{- with $author }}
-                            <author>
-                                <name>{{ .Params.name }}</name>
-                                <uri>{{ .Permalink }}</uri>
-                                {{- /* with .Params.email }}
-                                    <email>{{ . | plainify }}</email>
-                                {{ end */ -}}
-                            </author>
+                    <author>
+                        {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                            <name>{{ $author.Params.name | plainify }}</name>
+                        {{- else -}}
+                            <name>{{ . | plainify }}</name>
                         {{- end -}}
-                    {{- else }}
+                        {{- if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                            <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                        {{- else if $author }} <!-- link to profile page -->
+                            <uri>{{ $author.Permalink }}</uri>
+                        {{- end -}}
+                        {{- if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                            <email>{{ $author.Params.email | safeHTML }}</email>
+                        {{- end -}}
+                    </author>
+                {{ end }}
+            {{ else if and $authors (reflect.IsMap $authors) }} <!-- if authors are defined as map -->
+                {{ if isset $authors "name" }} <!-- this is a single author map -->
+                    {{ with $authors }}
+                        {{- $author := site.GetPage (printf "/%s/%s" "authors" .name) }}
                         <author>
-                            <name>{{ . }}</name>
+                            {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                                <name>{{ $author.Params.name | plainify }}</name>
+                            {{- else -}}
+                                <name>{{ .name | plainify }}</name>
+                            {{- end -}}
+                            {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                                <uri>{{ .uri | safeHTML }}</uri>
+                            {{- else if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                                <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                            {{- else if $author }} <!-- link to profile page -->
+                                <uri>{{ $author.Permalink }}</uri>
+                            {{- end -}}
+                            {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                                <email>{{ .email | plainify }}</email>
+                            {{- else if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                                <email>{{ $author.Params.email | safeHTML }}</email>
+                            {{- end -}}
                         </author>
-                    {{- end -}}
-                {{- end -}}
-            {{- end }}
+                    {{ end }}
+                {{ else }} <!-- this is a multi author map -->
+                    {{ range $elem_index, $elem_val := $authors }}
+                        {{- $name := $elem_index }}
+                        {{ if isset . "name" }}
+                            {{- $name = .name }}
+                        {{ end }}
+                        {{- $author := site.GetPage (printf "/%s/%s" "authors" $name) }}
+                        <author>
+                            {{- if and $author (isset $author.Params "name") }} <!-- use author name from profile page if found -->
+                                <name>{{ $author.Params.name | plainify }}</name>
+                            {{- else -}}
+                                <name>{{ $name | plainify }}</name>
+                            {{- end -}}
+                            {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                                <uri>{{ .uri | safeHTML }}</uri>
+                            {{- else if and $author (isset $author.Params "uri") }} <!-- use different author uri from profile page if found -->
+                                <uri>{{ $author.Params.uri | safeHTML }}</uri>
+                            {{- else if $author }} <!-- link to profile page -->
+                                <uri>{{ $author.Permalink }}</uri>
+                            {{- end -}}
+                            {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                                <email>{{ .email | plainify }}</email>
+                            {{- else if and $author (isset $author.Params "email") }} <!-- use author email from profile page if found -->
+                                <email>{{ $author.Params.email | safeHTML }}</email>
+                            {{- end -}}
+                        </author>
+                    {{ end }}
+                {{ end }}
+            {{ else if $authors }} <!-- simple author name -->
+                <author><name>{{ $authors | plainify }}</name></author>
+            {{ end }}
+
+            {{ $contributors := "" }}
+            {{ if isset .Params "contributor" }}
+                {{ $contributors = .Params.contributor }}
+            {{ else if isset .Params "contributors" }}
+                {{ $contributors = .Params.contributors }}
+            {{ end }}
+            {{ if and $contributors (reflect.IsSlice $contributors) }} <!-- if contributors are defined as slice -->
+                {{ range $contributors }}
+                    {{- $contributor := site.GetPage (printf "/%s/%s" "authors" .) }}
+                    <contributor>
+                        {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                            <name>{{ $contributor.Params.name | plainify }}</name>
+                        {{- else -}}
+                            <name>{{ . | plainify }}</name>
+                        {{- end -}}
+                        {{- if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                            <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                        {{- else if $contributor }} <!-- link to profile page -->
+                            <uri>{{ $contributor.Permalink }}</uri>
+                        {{- end -}}
+                        {{- if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                            <email>{{ $contributor.Params.email | safeHTML }}</email>
+                        {{- end -}}
+                    </contributor>
+                {{ end }}
+            {{ else if and $contributors (reflect.IsMap $contributors) }} <!-- if contributors are defined as map -->
+                {{ if isset $contributors "name" }} <!-- this is a single contributor map -->
+                    {{ with $contributors }}
+                        {{- $contributor := site.GetPage (printf "/%s/%s" "authors" .name) }}
+                        <contributor>
+                            {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                                <name>{{ $contributor.Params.name | plainify }}</name>
+                            {{- else -}}
+                                <name>{{ .name | plainify }}</name>
+                            {{- end -}}
+                            {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                                <uri>{{ .uri | safeHTML }}</uri>
+                            {{- else if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                                <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                            {{- else if $contributor }} <!-- link to profile page -->
+                                <uri>{{ $contributor.Permalink }}</uri>
+                            {{- end -}}
+                            {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                                <email>{{ .email | plainify }}</email>
+                            {{- else if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                                <email>{{ $contributor.Params.email | safeHTML }}</email>
+                            {{- end -}}
+                        </contributor>
+                    {{ end }}
+                {{ else }} <!-- this is a multi contributor map -->
+                    {{ range $elem_index, $elem_val := $contributors }}
+                        {{- $name := $elem_index }}
+                        {{ if isset . "name" }}
+                            {{- $name = .name }}
+                        {{ end }}
+                        {{- $contributor := site.GetPage (printf "/%s/%s" "authors" $name) }}
+                        <contributor>
+                            {{- if and $contributor (isset $contributor.Params "name") }} <!-- use contributor name from profile page if found -->
+                                <name>{{ $contributor.Params.name | plainify }}</name>
+                            {{- else -}}
+                                <name>{{ $name | plainify }}</name>
+                            {{- end -}}
+                            {{- if isset . "uri" }} <!-- explicitly overwrite uri -->
+                                <uri>{{ .uri | safeHTML }}</uri>
+                            {{- else if and $contributor (isset $contributor.Params "uri") }} <!-- use different contributor uri from profile page if found -->
+                                <uri>{{ $contributor.Params.uri | safeHTML }}</uri>
+                            {{- else if $contributor }} <!-- link to profile page -->
+                                <uri>{{ $contributor.Permalink }}</uri>
+                            {{- end -}}
+                            {{- if isset . "email" }} <!-- explicitly overwrite email -->
+                                <email>{{ .email | plainify }}</email>
+                            {{- else if and $contributor (isset $contributor.Params "email") }} <!-- use contributor email from profile page if found -->
+                                <email>{{ $contributor.Params.email | safeHTML }}</email>
+                            {{- end -}}
+                        </contributor>
+                    {{ end }}
+                {{ end }}
+            {{ else if $contributors }} <!-- simple contributor name -->
+                <contributor><name>{{ $contributors | plainify }}</name></contributor>
+            {{ end }}
+
             <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
             <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
             {{- if ne .Summary "" }}
@@ -133,11 +469,11 @@
                             {{- $taxonomy_page := . }}
                             {{- range $taxo_list }} <!-- Below, assuming pretty URLs -->
                                 <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
-                            {{- end }}
-                        {{- end }}
-                    {{- end }}
-                {{- end }}
-            {{- end }}
+                            {{ end }}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
         </entry>
     {{ end }}
 </feed>

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -82,10 +82,21 @@
         {{ $page := . }}
         <entry>
             {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
+            <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
+            {{- range .Translations }}
+                {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
+                {{- printf "<link href=%q rel=\"alternate\" type=\"text/html\" hreflang=%q />" $link .Lang | safeHTML }}
+            {{- end }}
+            {{- if site.Params.comments.engine | and (index site.Params.comments.commentable .Type) | and (ne .Params.commentable false) | or .Params.commentable }}
+                <link href="{{ .Permalink }}?utm_source=atom_feed#comments" rel="service.post" type="text/html" />
+            {{- end }}
+            {{- range first 5 (site.RegularPages.Related .) }}
+                <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
+            {{- end }}
             {{- $uuid := sha1 .RelPermalink }}
             <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
             {{- with .Params.authors -}}
-                {{- range . -}} <!-- Assuming the author front-matter to be a list -->
+                {{- range . -}} <!-- Assuming the authors front-matter to be a list -->
                     {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
                     {{- if $author.Params.name }}
                         {{- with $author }}
@@ -106,17 +117,6 @@
             {{- end }}
             <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
             <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-            <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
-            {{- range .Translations }}
-                {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
-                {{- printf "<link href=%q rel=\"alternate\" type=\"text/html\" hreflang=%q />" $link .Lang | safeHTML }}
-            {{- end }}
-            {{- if site.Params.comments.engine | and (index site.Params.comments.commentable .Type) | and (ne .Params.commentable false) | or .Params.commentable }}
-                <link href="{{ .Permalink }}?utm_source=atom_feed#comments" rel="service.post" type="text/html" />
-            {{- end }}
-            {{- range first 5 (site.RegularPages.Related .) }}
-                <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
-            {{- end }}
             {{- if ne .Summary "" }}
                 {{ printf `<summary type="html"><![CDATA[%s]]></summary>` .Summary | safeHTML }}
             {{- end }}

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -1,59 +1,141 @@
-<feed xmlns="http://www.w3.org/2005/Atom">
-    <generator>Hugo -- gohugo.io</generator>
-    <title>
-        {{- with .Title -}}
-            {{- if (not (eq . site.Title)) }}
-                {{ . }} on
-            {{ end }}
-        {{ end }}
-        {{ site.Title -}}
-    </title>
-    {{- with .OutputFormats.Get "atom" -}} <!-- Here, the Get is case-insensitive. -->
-        <link href="{{ .Permalink }}" rel="self" type="{{ .MediaType.Type }}" />
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<feed xmlns="http://www.w3.org/2005/Atom"{{ with site.LanguageCode }} xml:lang="{{.}}"{{- end -}}>
+  {{- $uuid := sha1 $.Site.BaseURL }}
+  <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
+  <title type="html">
+    {{- if ne .Title site.Title }}
+      {{- with .Title }}{{. | html }} | {{- end -}}
     {{- end -}}
-    <link href="{{ .Permalink }}"/>
-    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-    {{ with site.Author.name -}}
-        <author>
-            <name>{{ . }}</name>
-            {{ with site.Author.email }}
-                <email>{{ . }}</email>
-            {{ end -}}
-        </author>
+    {{- site.Title | html }}
+    {{- if .IsTranslated }} ({{- index site.Data.i18n.languages .Lang }}){{- end -}}
+  </title>
+  {{- if (.Params.Subtitle) and (ne .Params.Subtitle "") }}
+    <subtitle type="html">
+      {{- .Params.Subtitle | html -}}
+    </subtitle>
+  {{- else if ($.Site.Params.Subtitle) and (ne $.Site.Params.Subtitle "") }}
+    <subtitle type="html">
+      {{- $.Site.Params.Subtitle | html -}}
+    </subtitle>
+  {{- end }}
+  {{ with .OutputFormats.Get "HTML" }}
+    {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"Website\" />" .Permalink .MediaType | safeHTML }}
+  {{- end }}
+  {{ with .OutputFormats.Get "ATOM" }}
+    {{- printf "<link href=%q rel=\"self\" type=%q title=\"Atom/Modern feed format\" />" .Permalink .MediaType | safeHTML }}
+  {{- end }}
+  {{ with .OutputFormats.Get "RSS" }}
+    {{- printf "<link href=%q rel=\"alternate\" type=%q title=\"RSS/Legacy feed format\" />" .Permalink .MediaType | safeHTML }}
+  {{- end }}
+  {{- range .Translations }}
+    {{- $lang := .Lang }}
+    {{- $langstr := index site.Data.i18n.languages .Lang }}
+    {{ with .OutputFormats.Get "HTML" }}
+      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Website\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
     {{- end }}
-    <id>{{ .Permalink }}</id>
-    {{ $feed_sections := $.Site.Params.feedSections | default site.Params.mainSections }}
-    {{- range (where .Pages "Type" "in" $feed_sections) }}
-        {{ $page := . }}
-        <entry>
-            {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
-            <link href="{{ .Permalink }}"/>
-            <id>{{ .Permalink }}</id>
-            {{ with .Params.author -}}
-                {{- range . -}} <!-- Assuming the author front-matter to be a list -->
-                    <author>
-                        <name>{{ . }}</name>
-                    </author>
-                {{- end -}}
+    {{ with .OutputFormats.Get "ATOM" }}
+      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] Atom/Modern feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+    {{- end }}
+    {{ with .OutputFormats.Get "RSS" }}
+      {{- printf "<link href=%q rel=\"alternate\" type=%q hreflang=%q title=\"[%s] RSS/Legacy feed format\" />" .Permalink .MediaType $lang $langstr | safeHTML }}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq site.Params.comments.engine 1) (site.Params.comments.disqus.shortname) }}
+    <link href="https://{{- site.Params.comments.disqus.shortname }}.disqus.com/comments.rss" rel="comments" type="application/rss+xml" />
+  {{- end }}
+  <generator uri="https://gohugo.io/" version="{{hugo.Version}}">Hugo</generator>
+  {{- $author := site.GetPage (printf "/%s/%s" "authors" (.Scratch.Get "superuser_username")) }}
+  {{ with site.Author.name }}
+    <author>
+      <name>{{ . | plainify }}</name>
+      {{- with site.Author.email }}
+        <email>{{ . | plainify }}</email>
+      {{- end }}
+    </author>
+  {{- else }}
+    {{- with $author }}
+      <author>
+        <name>{{ .Params.name }}</name>
+        <uri>{{ .Permalink }}</uri>
+        {{- /* with .Params.email }}
+          <email>{{ . | plainify }}</email>
+        {{ end */ -}}
+      </author>
+    {{- end -}}
+  {{- end -}}
+  {{ with site.Copyright }}
+    <rights>
+      {{- replace (replace . "{year}" now.Year) "&copy;" "©" | plainify -}}
+    </rights>
+  {{- end }}
+  <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+  <icon>
+    {{- site.BaseURL }}img/icon-32.png{{- "" -}}
+  </icon>
+  <logo>
+    {{- site.BaseURL }}img/icon-512.png{{- "" -}}
+  </logo>
+
+  {{- $limit := (cond (le site.Config.Services.RSS.Limit 0) 65536 site.Config.Services.RSS.Limit) }}
+  {{- $feed_sections := $.Site.Params.feedSections | default site.Params.mainSections }}
+  {{ range first $limit (where (where .Pages "Type" "in" $feed_sections) ".Params.DisableFeed" "!=" true ) }}
+    {{ $page := . }}
+    <entry>
+      {{ printf `<title type="html"><![CDATA[%s]]></title>` .Title | safeHTML }}
+      {{- $uuid := sha1 .RelPermalink }}
+      <id>urn:uuid:{{substr $uuid 0 8}}-{{substr $uuid 8 4}}-5{{substr $uuid 13 3}}-{{substr $uuid 16 1}}9{{substr $uuid 17 2}}-{{substr $uuid 21 12}}</id>
+      {{- with .Params.authors -}}
+        {{- range . -}} <!-- Assuming the author front-matter to be a list -->
+          {{- $author := site.GetPage (printf "/%s/%s" "authors" .) }}
+          {{- if $author.Params.name }}
+            {{- with $author }}
+              <author>
+                <name>{{ .Params.name }}</name>
+                <uri>{{ .Permalink }}</uri>
+                {{- /* with .Params.email }}
+                  <email>{{ . | plainify }}</email>
+                {{ end */ -}}
+              </author>
+            {{- end -}}
+          {{- else }}
+            <author>
+              <name>{{ . }}</name>
+            </author>
+          {{- end -}}
+        {{- end -}}
+      {{- end }}
+      <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
+      <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+      <link href="{{ .Permalink }}?utm_source=atom_feed" rel="alternate" type="text/html" />
+      {{- range .Translations }}
+        {{- $link := printf "%s?utm_source=atom_feed" .Permalink | safeHTML }}
+        {{- printf "<link href=%q rel=\"alternate\" type=\"text/html\" hreflang=%q />" $link .Lang | safeHTML }}
+      {{- end }}
+      {{- if site.Params.comments.engine | and (index site.Params.comments.commentable .Type) | and (ne .Params.commentable false) | or .Params.commentable }}
+        <link href="{{ .Permalink }}?utm_source=atom_feed#comments" rel="service.post" type="text/html" />
+      {{- end }}
+      {{- range first 5 (site.RegularPages.Related .) }}
+        <link href="{{ .Permalink }}?utm_source=atom_feed" rel="related" type="text/html" title="{{ .Title }}" />
+      {{- end }}
+      {{- if ne .Summary "" }}
+        {{ printf `<summary type="html"><![CDATA[%s]]></summary>` .Summary | safeHTML }}
+      {{- end }}
+      {{- $description1 := .Description | default "" }}
+      {{- $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify))) }}
+      {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+      {{- with site.Taxonomies }}
+        {{- range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
+          {{- with $page.Param $taxo }}
+            {{- $taxo_list := . }} <!-- $taxo_list will be the tags/categories list -->
+            {{- with site.GetPage (printf "/%s" $taxo) }}
+              {{- $taxonomy_page := . }}
+              {{- range $taxo_list }} <!-- Below, assuming pretty URLs -->
+                <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
+              {{- end }}
             {{- end }}
-            <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
-            <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-            {{ $description1 := .Description | default "" }}
-            {{ $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify))) }}
-            {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
-            {{ with site.Taxonomies }}
-                {{ range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
-                    {{ with $page.Param $taxo }}
-                        {{ $taxo_list := . }} <!-- $taxo_list will be the tags/categories list -->
-                        {{ with site.GetPage (printf "/%s" $taxo) }}
-                            {{ $taxonomy_page := . }}
-                            {{ range $taxo_list }} <!-- Below, assuming pretty URLs -->
-                                <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
-                            {{ end }}
-                        {{ end }}
-                    {{ end }}
-                {{ end }}
-            {{ end }}
-        </entry>
-    {{ end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    </entry>
+  {{ end }}
 </feed>


### PR DESCRIPTION
This will add multi-language support for the feed as well as several additional attributes and handlings:

**Feed level**
- add missing XML declaration as first line
- use UUID, based on Site.BaseURL instead of site permalink for ID
- add language to title
- add page title to title (e.g. for taxonomy nodes)
- add subtitle (if parameter was configured)
- add alternate HTML link for other language
- add alternate links for other output formats besides HTML, including feed in other language
- add reference to Disqus comment feed if configured
- add Hugo version and URI to generator
- get author details from superuser_username of theme provides profile pages for authors and no author details are configured on site level
- add support for copyright note
- add icon
- add logo
- add limitation support for maximum entries
- allow to exclude specific pages using `.Params.DisableFeed = true`

**Entry level**
- use UUID, based on relative Permalink instead of site permalink for ID
- change page parameters for `author` to `authors`
- read author details from author profile page if theme supports it and the author was found
- add `?utm_source=atom_feed` to alternate HTML `<link>`
- add translation alternate HTML links
- add Atom API link to refer to the page comments section
- add 5 related HTML pages
- add summary in addition to content for the feed client to support teaser texts
