### PR TITLE
explicitly add outputFormat name for Atom

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@
   suffixes = ["xml"]
 [outputFormats.Atom]
   # https://validator.w3.org/feed/docs/atom.html#whatIsAtom
+  name = "Atom"
   mediaType = "application/atom+xml"
   baseName = "atom" # generated file = <baseName>.<mediaType."application/atom+xml".suffixes[0]> = atom.xml
   isPlainText = false


### PR DESCRIPTION
now that it can be visible to the end user on multi-lang sites, let's give it a proper name with capitalized first letter :-)