### PR TITLE
Fix output formats for translations

### DIFF
--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -22,6 +22,7 @@
         {{- end -}}
     {{- end }}
     {{- range .Translations }}
+        {{ $output_formats := .OutputFormats }}
         {{- $lang := .Lang }}
         {{- $langstr := index site.Data.i18n.languages .Lang }}
         {{ range $output_formats -}}


### PR DESCRIPTION
For translated sites, the OutputFormats of that translated site need to be used in order to get the correct permalink.

This fixes a bug introduced with commit https://github.com/kaushalmodi/hugo-atom-feed/commit/7679fdf7dc605375f2f058e987e5e222ba37a978