### PR TITLE
Add missing attributes to outputFormat

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,3 +13,7 @@
   mediaType = "application/atom+xml"
   baseName = "atom" # generated file = <baseName>.<mediaType."application/atom+xml".suffixes[0]> = atom.xml
   isPlainText = false
+  rel = "alternate"
+  isHTML = false
+  noUgly = true
+  permalinkable = false


### PR DESCRIPTION
this is just to complete the output format the same way as it is defined for RSS.