### PR TITLE
Adding <summary> support

### DIFF
--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -123,7 +123,7 @@
                     {{ printf `<summary><![CDATA[%s<p>&nbsp;</p>%s]]></summary>` $description $continue | safeHTML -}}
                 {{ else }}
                     {{ if ne "" $subtitle }}
-                        {{ printf `<summary><![CDATA[%s%s]]></summary>` $subtitle $continue | safeHTML }}
+                        {{ printf `<summary><![CDATA[<p>%s</p><p>&nbsp;</p>%s]]></summary>` $subtitle $continue | safeHTML }}
                     {{ else }}
                         {{ printf `<summary><![CDATA[%s]]></summary>` $continue | safeHTML }}
                     {{ end }}
@@ -134,7 +134,7 @@
                         {{ printf `<content><![CDATA[%s]]></content>` $content | safeHTML }}
                     {{ else }}
                         {{ if ne "" $subtitle }}
-                            {{ printf `<summary><![CDATA[%s%s]]></summary>` $subtitle $continue | safeHTML }}
+                            {{ printf `<summary><![CDATA[<p>%s</p><p>&nbsp;</p>%s]]></summary>` $subtitle $continue | safeHTML }}
                         {{ else }}
                             {{ printf `<summary><![CDATA[%s]]></summary>` $continue | safeHTML }}
                         {{ end }}

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -96,9 +96,59 @@
             {{- end }}
             <published>{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
             <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-            {{ $description1 := .Description | default "" }}
-            {{ $description := (cond (eq "" $description1) "" (printf "<blockquote>%s</blockquote>" ($description1 | markdownify))) }}
-            {{ printf `<content type="html"><![CDATA[%s%s]]></content>` $description .Content | safeHTML }}
+            {{- $description := "" -}}
+            {{- with .Description -}}
+                {{- $description = . -}}
+            {{- else -}}
+                {{- with .Summary -}}
+                    {{- $description = . -}}
+                {{- end -}}
+            {{- end -}}
+            {{- $description = (cond (eq "" $description) "" ($description | markdownify | emojify)) -}}
+            {{- $content := .Content -}}
+            {{- $subtitle := "" -}}
+            {{- with .Params.subtitle -}}
+                {{ $subtitle = . -}}
+                {{ $content = printf `<h2>%s</h2>%s` $subtitle $content | safeHTML -}}
+            {{- end -}}
+            {{- $description = (cond (eq "" $description) "" ($description | markdownify | emojify)) -}}
+            {{- $continue := i18n "feed_item_summary_readmore" | default "Read&nbsp;more&nbsp;&#8230;" -}}
+            {{- $link := printf `%s?utm_source=rss_feed` .Permalink -}}
+            {{- $continue = printf `<p><a href=%q>%s</a></p>` $link $continue | safeHTML -}}
+            {{ with .Params.disable_feed_content }}
+                {{ if ne "" $description }}
+                    {{ if ne "" $subtitle }}
+                        {{- $description = printf `<h2>%s</h2>%s` $subtitle $description | safeHTML -}}
+                    {{ end }}
+                    {{ printf `<summary><![CDATA[%s<p>&nbsp;</p>%s]]></summary>` $description $continue | safeHTML -}}
+                {{ else }}
+                    {{ if ne "" $subtitle }}
+                        {{ printf `<summary><![CDATA[%s%s]]></summary>` $subtitle $continue | safeHTML }}
+                    {{ else }}
+                        {{ printf `<summary><![CDATA[%s]]></summary>` $continue | safeHTML }}
+                    {{ end }}
+                {{ end }}
+            {{ else }}
+                {{ if eq "" $description }}
+                    {{ if ne "" $content }}
+                        {{ printf `<content><![CDATA[%s]]></content>` $content | safeHTML }}
+                    {{ else }}
+                        {{ if ne "" $subtitle }}
+                            {{ printf `<summary><![CDATA[%s%s]]></summary>` $subtitle $continue | safeHTML }}
+                        {{ else }}
+                            {{ printf `<summary><![CDATA[%s]]></summary>` $continue | safeHTML }}
+                        {{ end }}
+                    {{ end }}
+                {{ else if eq "" $content }}
+                    {{ if ne "" $subtitle }}
+                        {{- $description = printf `<h2>%s</h2>%s` $subtitle $description | safeHTML -}}
+                    {{ end }}
+                    {{ printf `<summary><![CDATA[%s<p>&nbsp;</p>%s]]></summary>` $description $continue | safeHTML -}}
+                {{ else }}
+                    {{ printf `<summary><![CDATA[%s]]></summary>` $description | safeHTML }}
+                    {{ printf `<content><![CDATA[%s]]></content>` $content | safeHTML }}
+                {{ end }}
+            {{ end }}
             {{ with site.Taxonomies }}
                 {{ range $taxo,$_ := . }} <!-- Defaults taxos: "tags", "categories" -->
                     {{ with $page.Param $taxo }}


### PR DESCRIPTION
This will add summary support.

- summary text may come from `$Page.description` or `$Page.summary`
- subtitle will be added to the content or summary text when appropriate and if available
- a localized text `Read more ...` will be added when only the summary text will show up (#2 )
- if summary and content is both there, both of it will be included
- a page parameter `.disable_feed_content` may be set to enforce truncating the text. Didn't want to introduce this on site level yet (it came too me just now ;-))

