### PR TITLE
Correct taxonomy declaration in category

### DIFF
--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -106,7 +106,7 @@
                         {{ with site.GetPage (printf "/%s" $taxo) }}
                             {{ $taxonomy_page := . }}
                             {{ range $taxo_list }} <!-- Below, assuming pretty URLs -->
-                                <category scheme="taxonomy:{{ printf "%s" $taxo }}" term="{{ (. | urlize) }}" label="{{ . }}" />
+                                <category scheme="taxonomy:{{ printf "%s" $taxo | humanize }}" term="{{ (. | urlize) }}" label="{{ . }}" />
                             {{ end }}
                         {{ end }}
                     {{ end }}

--- a/layouts/_default/list.atom.xml
+++ b/layouts/_default/list.atom.xml
@@ -106,7 +106,7 @@
                         {{ with site.GetPage (printf "/%s" $taxo) }}
                             {{ $taxonomy_page := . }}
                             {{ range $taxo_list }} <!-- Below, assuming pretty URLs -->
-                                <category scheme="{{ printf "%s%s" $taxonomy_page.Permalink (. | urlize) }}" term="{{ (. | urlize) }}" label="{{ . }}" />
+                                <category scheme="taxonomy:{{ printf "%s" $taxo }}" term="{{ (. | urlize) }}" label="{{ . }}" />
                             {{ end }}
                         {{ end }}
                     {{ end }}


### PR DESCRIPTION
Based on [this](https://movabletype.org/documentation/developer/api/atom-feeds/element-category.html), [this](http://www.rssboard.org/rss-profile#element-channel-item-category) and [my RSS derivate](https://github.com/jpawlowski/personal-website/blob/4a86cde16b4d28a97bbcb441e3a0cf1889927b9c/layouts/_default/list.rss#L169) of this feed template, I believe that the category should reflect the taxonomy type in a different scheme.

A [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) does not necessarily mean that it is a real URL / internet address (URI != URL, but URL = URI :-)).